### PR TITLE
FilterConfig: make `struct_derives` and `enum_derives` a list of strings

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -26,7 +26,7 @@ use std::{collections::HashMap, fs::File, path::Path};
 ///    - Debug
 ///    - Deserialize
 /// </pre>
-#[derive(Default, Deserialize)]
+#[derive(Deserialize)]
 pub struct FilterConfig {
     /// Names of schemes to include in the generated file
     pub include: Option<HashMap<String, SchemaFilter>>,
@@ -34,15 +34,36 @@ pub struct FilterConfig {
     pub exclude: Option<HashMap<String, SchemaFilter>>,
     /// Defines a list of `#[derive(...)]` when generating the structure. By
     /// default, `#[derive(Debug, Clone, serde::Deserialize)]`.
-    pub struct_derives: Option<Vec<String>>,
+    pub struct_derives: Vec<String>,
     /// Defines a list of `#[derive(...)]` when generating the enumeration. By
     /// default, `#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd,
     /// Ord, serde::Deserialize)]`.
-    pub enum_derives: Option<Vec<String>>,
+    pub enum_derives: Vec<String>,
     /// automatically adds schemas to the filter if the fields of another
     /// schema refer to it
     #[serde(default)]
     pub auto_include_dependencies: bool,
+}
+
+impl std::default::Default for FilterConfig {
+    fn default() -> Self {
+        Self {
+            struct_derives: vec!["Debug".into(), "Clone".into(), "Deserialize".into()],
+            enum_derives: vec![
+                "Debug".into(),
+                "Clone".into(),
+                "Copy".into(),
+                "PartialEq".into(),
+                "Eq".into(),
+                "PartialOrd".into(),
+                "Ord".into(),
+                "Deserialize".into(),
+            ],
+            include: Default::default(),
+            exclude: Default::default(),
+            auto_include_dependencies: Default::default(),
+        }
+    }
 }
 
 /// Filter element: either "*" or an array of strings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,8 @@ pub fn generate_openapi_types(
     writing::write_rust_code(
         &mut buf,
         &datatypes,
-        config.struct_derives.as_ref(),
-        config.enum_derives.as_ref(),
+        &config.struct_derives,
+        &config.enum_derives,
     )?;
 
     // removing the double line break to appease rustfmt


### PR DESCRIPTION
Closes #5.

Allow users to programmatically add more items to be derived.

Simplify the calls to `writeln!` when writing `#[derive()]` to the file.